### PR TITLE
Bulk insert changes for DataTable.  Based on some testing this could …

### DIFF
--- a/Timelapse2/Timelapse/Constant.cs
+++ b/Timelapse2/Timelapse/Constant.cs
@@ -98,8 +98,8 @@ namespace Timelapse
             // highlight / non-hightlight border thicknesses of a control
             public const double BorderThicknessNormal = 1;
             public const double BorderThicknessHighlight = 3;
-            public static readonly SolidColorBrush BorderColorNormal = new SolidColorBrush(Colors.LightBlue); 
-            public static readonly SolidColorBrush BorderColorHighlight = new SolidColorBrush(Colors.Blue); 
+            public static readonly SolidColorBrush BorderColorNormal = new SolidColorBrush(Colors.LightBlue);
+            public static readonly SolidColorBrush BorderColorHighlight = new SolidColorBrush(Colors.Blue);
 
             // a minty green
             public static readonly SolidColorBrush CopyableFieldHighlightBrush = new SolidColorBrush(Color.FromArgb(255, 200, 251, 200));
@@ -188,7 +188,7 @@ namespace Timelapse
         {
             public const string EmptyChoiceItem = "<EMPTY>"; // Indicates an empty item included in the choice menu list
         }
-            public static class ControlsDeprecated
+        public static class ControlsDeprecated
         {
             // MarkForDeletion data label was split between editor and Timelapse and normalized to DeleteFlag in 2.1.0.4
             public const string MarkForDeletion = "MarkForDeletion";
@@ -204,7 +204,7 @@ namespace Timelapse
             public const long InvalidID = -1;
             public const int InvalidRow = -1;
             public const int RelativePathPosition = 2;
-            public const int RowsPerInsert = 50000;
+            public const int RowsPerInsert = 500;
             public const int UtcOffsetPosition = 5;
             public const string DefaultSortTerms = Constant.DatabaseColumn.ID + "," + Constant.DatabaseColumn.ID + "," + Sql.Integer + "," + Constant.BooleanValue.True + ",,," + Constant.BooleanValue.True;
             public const string DefaultQuickPasteXML = "<Entries></Entries>";
@@ -221,7 +221,7 @@ namespace Timelapse
         public static class DatabaseColumn
         {
             public const string ID = "Id";
-            
+
             // columns in ImageDataTable
             public const string Date = "Date";
             public const string DateTime = "DateTime";
@@ -321,7 +321,7 @@ namespace Timelapse
             public static readonly TimeSpan PlayFastDefault = TimeSpan.FromMilliseconds(100.0);
             public static readonly TimeSpan PlayFastMaximum = TimeSpan.FromMilliseconds(500.0);
         }
-        
+
         // shorthands for FileSelection.<value>.ToString()
         public static class ImageQuality
         {
@@ -372,14 +372,14 @@ namespace Timelapse
             {
                 return new Lazy<BitmapImage>(() =>
                 {
-                // if the requested image is available as an application resource, prefer that
-                if (Application.Current != null && Application.Current.Resources.Contains(fileName))
+                    // if the requested image is available as an application resource, prefer that
+                    if (Application.Current != null && Application.Current.Resources.Contains(fileName))
                     {
                         return (BitmapImage)Application.Current.Resources[fileName];
                     }
 
-                // if it's not (editor, resource not listed in App.xaml) fall back to loading from the resources assembly
-                BitmapImage image = new BitmapImage();
+                    // if it's not (editor, resource not listed in App.xaml) fall back to loading from the resources assembly
+                    BitmapImage image = new BitmapImage();
                     image.BeginInit();
                     image.UriSource = new Uri("pack://application:,,/Resources/" + fileName);
                     image.EndInit();
@@ -672,6 +672,6 @@ namespace Timelapse
             public const string Category = "category";
             public const string Conf = "conf";
         }
-    #endregion
+        #endregion
     }
 }

--- a/Timelapse2/Timelapse/Database/FileDatabase.cs
+++ b/Timelapse2/Timelapse/Database/FileDatabase.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.SQLite;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
@@ -208,11 +209,13 @@ namespace Timelapse.Database
         #region Adding Files to the Database
         public void AddFiles(List<ImageRow> files, Action<ImageRow, int> onFileAdded)
         {
-            // We need to get a list of which columns are counters vs notes or fixed coices, 
-            // as we will shortly have to initialize them to some defaults
-            List<string> counterList = new List<string>();
-            List<string> notesAndFixedChoicesList = new List<string>();
-            List<string> flagsList = new List<string>();
+            StringBuilder queryColumns = new StringBuilder("insert into DataTable (");
+            int rowNumber = 0;
+            Dictionary<string, string> defaultValueLookup = this.GetDefaultControlValueLookup();
+
+            // We need to get a list of which columns are counters
+            HashSet<string> counterList = new HashSet<string>();
+
             foreach (string columnName in this.FileTable.ColumnNames)
             {
                 if (columnName == Constant.DatabaseColumn.ID)
@@ -221,31 +224,26 @@ namespace Timelapse.Database
                     continue;
                 }
 
-                string controlType = this.FileTableColumnsByDataLabel[columnName].ControlType;
-                if (controlType.Equals(Constant.Control.Counter))
-                {
-                    counterList.Add(columnName);
-                }
-                else if (controlType.Equals(Constant.Control.Note) || controlType.Equals(Constant.Control.FixedChoice))
-                {
-                    notesAndFixedChoicesList.Add(columnName);
-                }
-                else if (controlType.Equals(Constant.Control.Flag))
-                {
-                    flagsList.Add(columnName);
-                }
+                queryColumns.Append(columnName);
+                queryColumns.Append(",");
             }
 
-            // Create a dataline from each of the image properties, add it to a list of data lines,
-            // then do a multiple insert of the list of datalines to the database 
+            queryColumns.Remove(queryColumns.Length - 1, 1);
+            queryColumns.Append(") VALUES ");
+
+            // Create a dataline from each of the image properties, add it to a list of data lines, then do a multiple insert of the list of datalines to the database
             for (int image = 0; image < files.Count; image += Constant.DatabaseValues.RowsPerInsert)
             {
-                // Create a dataline from the image properties, add it to a list of data lines,
-                // then do a multiple insert of the list of datalines to the database 
-                List<List<ColumnTuple>> fileDataRows = new List<List<ColumnTuple>>();
+                // Create a dataline from the image properties, add it to a list of data lines, then do a multiple insert of the list of datalines to the database
                 List<List<ColumnTuple>> markerRows = new List<List<ColumnTuple>>();
+                SQLiteCommand command = new SQLiteCommand();
+                StringBuilder queryValues = new StringBuilder();
+                Dictionary<string, Dictionary<string, string>> parameterLookup = new Dictionary<string, Dictionary<string, string>>();
+
                 for (int insertIndex = image; (insertIndex < (image + Constant.DatabaseValues.RowsPerInsert)) && (insertIndex < files.Count); insertIndex++)
                 {
+                    queryValues.Append("(");
+
                     List<ColumnTuple> imageRow = new List<ColumnTuple>();
                     List<ColumnTuple> markerRow = new List<ColumnTuple>();
                     foreach (string columnName in this.FileTable.ColumnNames)
@@ -261,74 +259,55 @@ namespace Timelapse.Database
                         ImageRow imageProperties = files[insertIndex];
                         switch (controlType)
                         {
-                            case Constant.DatabaseColumn.File: // Add The File name
-                                string dataLabel = this.DataLabelFromStandardControlType[Constant.DatabaseColumn.File];
-                                imageRow.Add(new ColumnTuple(dataLabel, imageProperties.File));
+                            case Constant.DatabaseColumn.File:
+                                queryValues.Append($"{Utilities.QuoteForSql(imageProperties.File)},");
                                 break;
-                            case Constant.DatabaseColumn.RelativePath: // Add the relative path name
-                                dataLabel = this.DataLabelFromStandardControlType[Constant.DatabaseColumn.RelativePath];
-                                imageRow.Add(new ColumnTuple(dataLabel, imageProperties.RelativePath));
+
+                            case Constant.DatabaseColumn.RelativePath:
+                                queryValues.Append($"{Utilities.QuoteForSql(imageProperties.RelativePath)},");
                                 break;
-                            case Constant.DatabaseColumn.Folder: // Add The Folder name
-                                dataLabel = this.DataLabelFromStandardControlType[Constant.DatabaseColumn.Folder];
-                                imageRow.Add(new ColumnTuple(dataLabel, imageProperties.Folder));
+
+                            case Constant.DatabaseColumn.Folder:
+                                queryValues.Append($"{Utilities.QuoteForSql(imageProperties.Folder)},");
                                 break;
+
                             case Constant.DatabaseColumn.Date:
-                                // Add the date
-                                dataLabel = this.DataLabelFromStandardControlType[Constant.DatabaseColumn.Date];
-                                imageRow.Add(new ColumnTuple(dataLabel, imageProperties.Date));
+                                queryValues.Append($"{Utilities.QuoteForSql(imageProperties.Date)},");
                                 break;
+
                             case Constant.DatabaseColumn.DateTime:
-                                dataLabel = this.DataLabelFromStandardControlType[Constant.DatabaseColumn.DateTime];
-                                imageRow.Add(new ColumnTuple(dataLabel, imageProperties.DateTime));
+                                queryValues.Append($"{Utilities.QuoteForSql(DateTimeHandler.ToDatabaseDateTimeString(imageProperties.DateTime))},");
                                 break;
+
                             case Constant.DatabaseColumn.UtcOffset:
-                                dataLabel = this.DataLabelFromStandardControlType[Constant.DatabaseColumn.UtcOffset];
-                                imageRow.Add(new ColumnTuple(dataLabel, imageProperties.UtcOffset));
+                                queryValues.Append($"{Utilities.QuoteForSql(DateTimeHandler.ToDatabaseUtcOffsetString(imageProperties.UtcOffset))},");
                                 break;
+
                             case Constant.DatabaseColumn.Time:
-                                // Add the time
-                                dataLabel = this.DataLabelFromStandardControlType[Constant.DatabaseColumn.Time];
-                                imageRow.Add(new ColumnTuple(dataLabel, imageProperties.Time));
+                                queryValues.Append($"{Utilities.QuoteForSql(imageProperties.Time)},");
                                 break;
-                            case Constant.DatabaseColumn.ImageQuality: // Add the Image Quality
-                                dataLabel = this.DataLabelFromStandardControlType[Constant.DatabaseColumn.ImageQuality];
-                                imageRow.Add(new ColumnTuple(dataLabel, imageProperties.ImageQuality.ToString()));
+
+                            case Constant.DatabaseColumn.ImageQuality:
+                                queryValues.Append($"{Utilities.QuoteForSql(imageProperties.ImageQuality.ToString())},");
                                 break;
-                            case Constant.DatabaseColumn.DeleteFlag: // Add the Delete flag
-                                dataLabel = this.DataLabelFromStandardControlType[Constant.DatabaseColumn.DeleteFlag];
-                                imageRow.Add(new ColumnTuple(dataLabel, this.GetControlDefaultValue(dataLabel))); // Default as specified in the template file, which should be "false"
+
+                            case Constant.DatabaseColumn.DeleteFlag:
+                                string dataLabel = this.DataLabelFromStandardControlType[Constant.DatabaseColumn.DeleteFlag];
+
+                                // Default as specified in the template file, which should be "false"
+                                queryValues.Append($"{Utilities.QuoteForSql(defaultValueLookup[dataLabel])},");
                                 break;
+
                             case Constant.Control.Note:        // Find and then Add the Note or Fixed Choice
                             case Constant.Control.FixedChoice:
-                                // Now initialize notes, counters, and fixed choices to the defaults
-                                foreach (string controlName in notesAndFixedChoicesList)
-                                {
-                                    if (columnName.Equals(controlName))
-                                    {
-                                        imageRow.Add(new ColumnTuple(controlName, this.GetControlDefaultValue(controlName))); // Default as specified in the template file
-                                    }
-                                }
-                                break;
                             case Constant.Control.Flag:
-                                // Now initialize flags to the defaults
-                                foreach (string controlName in flagsList)
-                                {
-                                    if (columnName.Equals(controlName))
-                                    {
-                                        imageRow.Add(new ColumnTuple(controlName, this.GetControlDefaultValue(controlName))); // Default as specified in the template file
-                                    }
-                                }
+                                // Now initialize notes, flags, and fixed choices to the defaults
+                                queryValues.Append($"{Utilities.QuoteForSql(defaultValueLookup[columnName])},");
                                 break;
+
                             case Constant.Control.Counter:
-                                foreach (string controlName in counterList)
-                                {
-                                    if (columnName.Equals(controlName))
-                                    {
-                                        imageRow.Add(new ColumnTuple(controlName, this.GetControlDefaultValue(controlName))); // Default as specified in the template file
-                                        markerRow.Add(new ColumnTuple(controlName, String.Empty));
-                                    }
-                                }
+                                queryValues.Append($"{Utilities.QuoteForSql(defaultValueLookup[columnName])},");
+                                markerRow.Add(new ColumnTuple(columnName, String.Empty));
                                 break;
 
                             default:
@@ -336,15 +315,24 @@ namespace Timelapse.Database
                                 break;
                         }
                     }
-                    fileDataRows.Add(imageRow);
+
+                    // Remove trailing comma.
+                    queryValues.Remove(queryValues.Length - 1, 1);
+                    queryValues.Append("),");
+                    ++rowNumber;
+
                     if (markerRow.Count > 0)
                     {
                         markerRows.Add(markerRow);
                     }
                 }
 
+                // Remove trailing comma.
+                queryValues.Remove(queryValues.Length - 1, 1);
+                command.CommandText = queryColumns.ToString() + queryValues.ToString();
+
                 this.CreateBackupIfNeeded();
-                this.InsertRows(Constant.DBTables.FileData, fileDataRows);
+                this.Database.ExecuteCommand(command);
                 this.InsertRows(Constant.DBTables.Markers, markerRows);
 
                 if (onFileAdded != null)
@@ -357,6 +345,7 @@ namespace Timelapse.Database
             // Load / refresh the marker table from the database to keep it in sync - Doing so here will make sure that there is one row for each image.
             this.GetMarkers();
         }
+
         #endregion
         public void AppendToImageSetLog(StringBuilder logEntry)
         {
@@ -1857,6 +1846,24 @@ namespace Timelapse.Database
             return new ColumnDefinition(control.DataLabel, Sql.Text, control.DefaultValue);
         }
 
+        /// <summary>
+        /// Gets a dictionary populated with control default values based on the control data label.
+        /// </summary>
+        /// <returns></returns>
+        private Dictionary<string, string> GetDefaultControlValueLookup()
+        {
+            Dictionary<string, string> results = new Dictionary<string, string>();
+            foreach (ControlRow control in this.Controls)
+            {
+                if (!results.ContainsKey(control.DataLabel))
+                {
+                    results.Add(control.DataLabel, control.DefaultValue);
+                }
+            }
+
+            return results;
+        }
+
         #region DETECTION INTEGRATION
         public bool PopulateDetectionTables(string path)
         {
@@ -1869,7 +1876,7 @@ namespace Timelapse.Database
             {
                 // PERFORMANCE Reading in very large json tables is somewhat slow. I am not sure if this can be optimized as the entire file is needed.
                 using (Detector detector = JsonConvert.DeserializeObject<Detector>(File.ReadAllText(path)))
-                 {
+                {
                     // If detection population was previously done in this session, resetting these tables to null 
                     // will force reading the new values into them
                     this.detectionDataTable = null; // to force repopulating the data structure if it already exists.
@@ -2112,7 +2119,7 @@ namespace Timelapse.Database
                 // its important to show detection and category data (including bounding boxes) as rapidly as possible, such as when a user is quickly scrolling through images.
                 // So I am not clear on how to optimize this (although I suspect a thread running in the background when Timelapse is loaded could perhaps do this)
                 if (this.detectionCategoriesDictionary == null)
-                { 
+                {
                     this.classificationCategoriesDictionary = new Dictionary<string, string>();
                 }
                 DataTable dataTable = this.Database.GetDataTableFromSelect(Sql.SelectStarFrom + Constant.DBTables.ClassificationCategories);

--- a/Timelapse2/Timelapse/Database/SQLiteWrapper.cs
+++ b/Timelapse2/Timelapse/Database/SQLiteWrapper.cs
@@ -61,7 +61,7 @@ namespace Timelapse.Database
             query = query.Remove(query.Length - Sql.Comma.Length - Environment.NewLine.Length);         // remove last comma / new line and replace with );
             query += Sql.CloseParenthesis + Sql.Semicolon;
             this.ExecuteNonQuery(query);
-        } 
+        }
 
         #region Indexes: Create or Drop
         // Create an index in table tableName named index name to the column names
@@ -218,7 +218,7 @@ namespace Timelapse.Database
         {
             try
             {
-                using (SQLiteConnection connection = this.GetNewSqliteConnection(this.connectionString)) 
+                using (SQLiteConnection connection = this.GetNewSqliteConnection(this.connectionString))
                 {
                     connection.Open();
                     using (SQLiteCommand command = new SQLiteCommand(connection))
@@ -243,7 +243,7 @@ namespace Timelapse.Database
         {
             try
             {
-                using (SQLiteConnection connection = this.GetNewSqliteConnection(this.connectionString)) 
+                using (SQLiteConnection connection = this.GetNewSqliteConnection(this.connectionString))
                 {
                     connection.Open();
                     using (SQLiteCommand command = new SQLiteCommand(connection))
@@ -275,7 +275,7 @@ namespace Timelapse.Database
             string mostRecentStatement = null;
             try
             {
-                using (SQLiteConnection connection = this.GetNewSqliteConnection(this.connectionString)) 
+                using (SQLiteConnection connection = this.GetNewSqliteConnection(this.connectionString))
                 {
                     connection.Open();
 
@@ -320,6 +320,30 @@ namespace Timelapse.Database
             catch (Exception exception)
             {
                 TraceDebug.PrintMessage(String.Format("Failure near executing statement '{0}' n ExecuteNonQueryWrappedInBeginEnd. {1}", mostRecentStatement, exception.ToString()));
+            }
+        }
+
+        /// <summary>
+        /// Executes the incoming <see cref="SQLiteCommand"/>.
+        /// </summary>
+        /// <param name="command">The command to execute.</param>
+        public void ExecuteCommand(SQLiteCommand command)
+        {
+            if (command != null && !string.IsNullOrEmpty(command.CommandText))
+            {
+                try
+                {
+                    using (SQLiteConnection connection = this.GetNewSqliteConnection(this.connectionString))
+                    {
+                        connection.Open();
+                        command.Connection = connection;
+                        command.ExecuteNonQuery();
+                    }
+                }
+                catch (Exception exception)
+                {
+                    TraceDebug.PrintMessage(String.Format("Failure near executing statement '{0}' n ExecuteNonQueryWrappedInBeginEnd. {1}", command.CommandText, exception.ToString()));
+                }
             }
         }
 
@@ -369,7 +393,7 @@ namespace Timelapse.Database
                 }
                 queries.Add(query);
             }
-            this.ExecuteNonQueryWrappedInBeginEnd(queries); 
+            this.ExecuteNonQueryWrappedInBeginEnd(queries);
         }
 
         /// <summary>
@@ -549,7 +573,7 @@ namespace Timelapse.Database
                 return false;
             }
         }
-        
+
         /// <summary>
         /// Add a column to the table named sourceTable at position columnNumber using the provided columnDefinition
         /// The value in columnDefinition is assumed to be the desired default value


### PR DESCRIPTION
Bulk insert changes for DataTable.  Based on some testing this could improve database insert performance anywhere between %15 - %50
 - Performing a single bulk insert per batch of files.
 - Generating statement using a StringBuilder
 - Changed the insert commit rate to 500 (this would eventually be faster for distributed databases, but doesn't matter as much for SQLite on the same machine).

I can send the Testing file I used for the timings if needed.